### PR TITLE
feat: load model from registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+mlruns/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/model_registry/load_model_from_registry.py
+++ b/src/model_registry/load_model_from_registry.py
@@ -1,0 +1,35 @@
+import os
+
+import click
+import mlflow
+import pandas as pd
+from sklearn.metrics import accuracy_score
+
+from src.model_development.base_train import load_data, preprocess
+
+os.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://localhost:9000"
+os.environ["MLFLOW_TRACKING_URI"] = "http://localhost:5001"
+os.environ["AWS_ACCESS_KEY_ID"] = "minio"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "miniostorage"
+
+
+@click.command()
+@click.option("--run-id", help="Run ID", type=click.STRING)
+@click.option("--model-name", help="Name of the model", type=click.STRING)
+def main(run_id: str, model_name: str) -> None:
+    # Load model as a PyFuncModel.
+    loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/{model_name}")
+
+    # Predict on a Pandas DataFrame.
+
+    X_train, X_test, y_train, y_test = preprocess(load_data())
+
+    pred_train = loaded_model.predict(pd.DataFrame(X_train))
+    pred_test = loaded_model.predict(pd.DataFrame(X_test))
+
+    print("Train accuracy:", accuracy_score(y_train, pred_train))
+    print("Test accuracy:", accuracy_score(y_test, pred_test))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model_registry/save_model_to_registry.py
+++ b/src/model_registry/save_model_to_registry.py
@@ -7,6 +7,7 @@ from mlflow.models.signature import infer_signature
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
+
 from src.model_development.base_train import load_data, preprocess
 
 os.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://localhost:9000"
@@ -31,6 +32,8 @@ def main(model_name: str) -> None:
 
     signature = infer_signature(X_train, pipeline.predict(X_train))
     input_example = X_train.iloc[:5, :]
+
+    mlflow.set_experiment("new-experiment")
 
     with mlflow.start_run():
         mlflow.log_metric("train_accuracy", pipeline.score(X_train, y_train))


### PR DESCRIPTION
## Description

다음 요구사항을 구현하였습니다.

1. 학습이 끝난 모델을 MLflow built-in method 를 사용하여 MLflow 서버에서 불러온다.
    - 2) Save Model to Registry 챕터에서 설치한 `mlflow` 패키지를 사용한다.
    - 학습에 관련된 정보가 저장 되어있는 `run` 의 `run_id` 를 사용하여 모델을 불러온다.
    - `mlflow` 패키지를 이용하여 모델을 불러오는 방법은 두 가지가 있다.
        1. [[MLFlow built-in Model Flavors](https://www.mlflow.org/docs/latest/models.html#built-in-model-flavors)](https://www.mlflow.org/docs/latest/models.html#built-in-model-flavors)
        2. [[MLFLow pyfunc load_model](https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.load_model)](https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.load_model)
    - 이번 챕터에서는 `sklearn` 의 모델을 불러오기 위해 `mlflow.sklean.load_model` 을 사용한다.
2. 불러온 모델을 이용하여 2) Save Model to Registry 챕터에서 저장해두었던 학습 데이터의 결과를 추론한다.