### PR TITLE
build: fastapi on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,3 +43,10 @@ ENV PATH="$PATH:$HOME/minio-binaries/"
 COPY --from=package_installer /usr/local/bin /usr/local/bin
 COPY --from=package_installer /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY . .
+
+FROM base as fastapi_server
+COPY --from=package_installer /usr/local/bin /usr/local/bin
+COPY --from=package_installer /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+COPY . .
+ENTRYPOINT ["uvicorn"]
+CMD ["--app-dir", "src/fastapi_tutorial", "--host", "0.0.0.0", "crud_pydantic:app", "--reload"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,6 +111,15 @@ services:
         --default-artifact-root s3://mlflow/ \
         --host 0.0.0.0
 
+  fastapi-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: fastapi_server
+    container_name: fastapi-server
+    ports:
+      - "8000:8000"
+
 networks:
   default:
     name: mlops-network


### PR DESCRIPTION
## Description

다음 요구사항을 구현하였습니다.

**Specifications**

1. 앞서 Pydantic 을 이용하여 수정한 API 를 서버로 실행하기 위해 Dockerfile 을 작성한다.
    - Base image는 `amd64/python:3.10-slim` 을 사용한다.
    - `crud_pydantic.py` 를 이용한다.
    - 포트는 기본 포트인 8000번 포트를 이용한다.
2. `[http://localhost:8000/docs](http://localhost:8000/docs)` 에 접속하여 앞서 수행한 시나리오가 제대로 작동하는지 확인한다